### PR TITLE
Changed the cache storage structure

### DIFF
--- a/src/main/kotlin/im/toss/util/cache/Cache.kt
+++ b/src/main/kotlin/im/toss/util/cache/Cache.kt
@@ -8,7 +8,7 @@ import kotlin.random.Random
 
 open class Cache(override val name: String) : CacheMeter {
     data class KeyFunction(
-        val function: (name: String, version: String, key: Any) -> String
+        val function: (name: String, key: Any) -> String
     )
 
 

--- a/src/main/kotlin/im/toss/util/cache/CacheManager.kt
+++ b/src/main/kotlin/im/toss/util/cache/CacheManager.kt
@@ -33,7 +33,7 @@ class CacheManager(
                 name = name,
                 keyFunction = keyFunction,
                 lock = resouces.lock(lockAutoreleaseSeconds),
-                repository = resouces.keyValueRepository(),
+                repository = resouces.keyFieldValueRepository(),
                 serializer = getSerializer(serializerId),
                 options = options
             ).metrics(meterRegistry)
@@ -61,9 +61,7 @@ class CacheManager(
         } as MultiFieldCache<TKey>
     }
 
-    private var keyFunction: Cache.KeyFunction = Cache.KeyFunction { name, version, key ->
-        "cache:$name.$version:$key"
-    }
+    private var keyFunction: Cache.KeyFunction = Cache.KeyFunction { name, key -> "cache:$name:$key" }
 
     private val resources = ConcurrentHashMap<String, CacheResources>()
     private val serializers = ConcurrentHashMap<String, Serializer>()
@@ -111,7 +109,7 @@ class CacheManager(
     }
 
     class ResoucesDefinition(private val cacheManager: CacheManager) {
-        fun keyFunction(block: (name: String, version: String, key: Any) -> String) {
+        fun keyFunction(block: (name: String, key: Any) -> String) {
             cacheManager.setKeyFunction(Cache.KeyFunction(block))
         }
 

--- a/src/main/kotlin/im/toss/util/cache/KeyValueCache.kt
+++ b/src/main/kotlin/im/toss/util/cache/KeyValueCache.kt
@@ -2,167 +2,24 @@ package im.toss.util.cache
 
 import im.toss.util.cache.blocking.BlockingKeyValueCache
 import im.toss.util.concurrent.lock.MutexLock
-import im.toss.util.concurrent.lock.run
-import im.toss.util.concurrent.lock.runOrRetry
-import im.toss.util.coroutine.runWithTimeout
 import im.toss.util.data.serializer.Serializer
-import im.toss.util.repository.KeyValueRepository
-import kotlinx.coroutines.TimeoutCancellationException
+import im.toss.util.repository.KeyFieldValueRepository
 
 class KeyValueCache<TKey: Any>(
     override val name: String,
     keyFunction: KeyFunction,
-    private val lock: MutexLock,
-    private val repository: KeyValueRepository,
-    private val serializer: Serializer,
+    lock: MutexLock,
+    repository: KeyFieldValueRepository,
+    serializer: Serializer,
     val options: CacheOptions
 ) : Cache(name) {
     fun blocking() = BlockingKeyValueCache(this)
 
-    private val keys = Keys<TKey>(name, keyFunction, options)
+    private val cache = MultiFieldCache<TKey>(name, keyFunction, lock, repository, serializer, options)
+    private val field = ".value"
 
-    suspend fun evict(key: TKey) {
-        incrementEvictCount()
-        setColdTime(key)
-        setEvicted(key)
-        repository.delete(keys.key(key))
-    }
-
-    suspend fun <T: Any> load(key: TKey, fetch: (suspend () -> T)) {
-        if (options.cacheMode == CacheMode.EVICTION_ONLY) {
-            evict(key)
-        } else {
-            try {
-                runOrRetry {
-                    loadToCache(key, fetch)
-                }
-            } catch (e: Throwable) {
-                options.cacheFailurePolicy.handle("KeyValueCache.load(): exception occured on load: cache=$name, key=$key", e)
-            }
-        }
-    }
-
-    private suspend fun <T: Any> loadToCache(key: TKey, fetch: (suspend () -> T)): T {
-        return lock.run(keys.fetchKey(key)) {
-            setNotEvicted(key)
-            val fetched = fetch()
-            if (isNotEvicted(key)) {
-                val dataBytes = serializer.serialize(fetched)
-                repository.set(keys.key(key), dataBytes, options.ttl, options.ttlTimeUnit)
-                incrementPutCount()
-            }
-            fetched
-        }
-    }
-
-    suspend fun <T: Any> get(key: TKey): T? {
-        if (options.cacheMode == CacheMode.EVICTION_ONLY) {
-            incrementMissCount()
-            return null
-        }
-
-        try {
-            return when (val cached = readFromCache<T>(key)) {
-                null -> {
-                    incrementMissCount()
-                    null
-                }
-                else -> {
-                    incrementHitCount()
-                    if (options.applyTtlIfHit && options.ttl > 0L) {
-                        repository.expire(keys.key(key), options.ttl, options.ttlTimeUnit)
-                    }
-                    cached
-                }
-            }
-        } catch (e: TimeoutCancellationException) {
-            options.cacheFailurePolicy.handle("KeyValueCache.get(): timeout occured on read from cache: cache=$name, key=$key", e)
-        } catch (e: Throwable) {
-            options.cacheFailurePolicy.handle("KeyValueCache.get(): exception occured on read from cache: cache=$name, key=$key", e)
-        }
-        incrementMissCount()
-        return null
-    }
-
-    suspend fun <T: Any> getOrLoad(key: TKey, fetch: (suspend () -> T)): T {
-        if (options.cacheMode == CacheMode.EVICTION_ONLY) {
-            incrementMissCount()
-            return fetch()
-        }
-
-        try {
-            return runOrRetry {
-                when (val cached = readFromCache<T>(key)) {
-                    null -> if (isColdTime(key)) {
-                        incrementMissCount()
-                        fetch()
-                    } else loadToCache(key) {
-                        incrementMissCount()
-                        fetch()
-                    }
-                    else -> {
-                        incrementHitCount()
-                        if (options.applyTtlIfHit && options.ttl > 0L) {
-                            repository.expire(keys.key(key), options.ttl, options.ttlTimeUnit)
-                        }
-                        cached
-                    }
-                }
-            }
-        } catch (e: TimeoutCancellationException) {
-            options.cacheFailurePolicy.handle("KeyValueCache.getOrLoad(): timeout occured on read from cache: cache=$name, key=$key", e)
-        } catch (e: Throwable) {
-            options.cacheFailurePolicy.handle("KeyValueCache.getOrLoad(): exception occured on read from cache: cache=$name, key=$key", e)
-        }
-        incrementMissCount()
-        return fetch()
-    }
-
-    private suspend fun <T> readFromCache(key: TKey): T? {
-        val cachedData = repository.get(keys.key(key))
-        return if (cachedData == null) {
-            null
-        } else {
-            try {
-                serializer.deserialize<T>(cachedData)
-            } catch (e: Throwable) {
-                null
-            }
-        }
-    }
-
-
-    private class Keys<K: Any>(
-        private val name: String,
-        private val keyFunction: KeyFunction,
-        val options: CacheOptions
-    ) {
-        fun key(key: K): String = keyFunction.function(name, options.version, key)
-
-        fun lock(key: K, postfix: String): String = "${key(key)}|$postfix"
-        fun cold(key:K) = lock(key, "@COLD")
-        fun fetchKey(key:K) = lock(key, "@FETCH")
-        fun notEvicted(key: K) = lock(key, "@NOTEVICT")
-
-    }
-
-    private fun useColdTime(): Boolean {
-        return options.coldTime > 0L
-    }
-
-    private suspend fun setColdTime(key: TKey) {
-        if (useColdTime()) {
-            lock.acquire(keys.cold(key), options.coldTime, options.coldTimeUnit)
-        }
-    }
-
-    private suspend fun isColdTime(key: TKey): Boolean {
-        return if (useColdTime()) {
-            return lock.isAcquired(keys.cold(key))
-        } else false
-    }
-
-    private suspend fun setEvicted(key: TKey) = repository.delete(keys.notEvicted(key))
-    private suspend fun setNotEvicted(key: TKey) = repository.set(keys.notEvicted(key), "1".toByteArray(), options.evictCheckTTL, options.evictCheckTimeUnit)
-    private suspend fun isNotEvicted(key: TKey) = repository.delete(keys.notEvicted(key))
+    suspend fun evict(key: TKey) = cache.evict(key)
+    suspend fun <T: Any> load(key: TKey, fetch: (suspend () -> T)) = cache.load(key, field, fetch)
+    suspend fun <T: Any> get(key: TKey): T? = cache.get(key, field)
+    suspend fun <T: Any> getOrLoad(key: TKey, fetch: (suspend () -> T)): T = cache.getOrLoad(key, field, fetch)
 }

--- a/src/test/kotlin/im/toss/util/cache/BlockingMultiFieldCacheTest.kt
+++ b/src/test/kotlin/im/toss/util/cache/BlockingMultiFieldCacheTest.kt
@@ -18,7 +18,7 @@ import kotlin.system.measureTimeMillis
 class BlockingMultiFieldCacheTest {
     fun testCache(repository: KeyFieldValueRepository? = null, ttl:Long = 100L, coldTime: Long = 0L, applyTtlIfHit: Boolean = true) = MultiFieldCache<String>(
         name = "dict_cache",
-        keyFunction = Cache.KeyFunction { name, version, key -> "$name.$version:{$key}" },
+        keyFunction = Cache.KeyFunction { name, key -> "$name:{$key}" },
         lock = LocalMutexLock(5000),
         repository = repository ?: TestKeyFieldValueRepository(),
         serializer = StringSerializer,

--- a/src/test/kotlin/im/toss/util/cache/CacheManagerTest.kt
+++ b/src/test/kotlin/im/toss/util/cache/CacheManagerTest.kt
@@ -15,7 +15,7 @@ internal class CacheManagerTest {
     fun `inMemory keyValueCache`() {
         runBlocking {
             val cacheManager = CacheManager(SimpleMeterRegistry()) {
-                keyFunction { name, version, key -> "$name.$version:$key" }
+                keyFunction { name, key -> "$name:$key" }
                 inMemory()
                 serializer { StringSerializer }
             }
@@ -45,7 +45,7 @@ internal class CacheManagerTest {
     fun `inMemory multiFieldCache`() {
         runBlocking {
             val cacheManager = CacheManager(SimpleMeterRegistry()) {
-                keyFunction { name, version, key -> "$name.$version:$key" }
+                keyFunction { name, key -> "$name:$key" }
                 inMemory()
                 serializer { StringSerializer }
             }


### PR DESCRIPTION
If multiple app versions coexist in the deployment, even if the cache version changes, you can deploy them at once without conflict.
1. multi-key-field cache: version info has been moved from key to field.
2. key-field-cache: changed to share the multi-field-cache inside.